### PR TITLE
4 architectures

### DIFF
--- a/scripts/interactive_inference_synthetic.py
+++ b/scripts/interactive_inference_synthetic.py
@@ -13,7 +13,7 @@ def main(argv):
     args = parser.parse_args(argv)
     plug_crop_selector(num_pad=args.keyboard)
     model_dict = get_default_models(args.experiments, Path(args.models_storage))
-    dead_leave_plugin(ds=5)
+    dead_leave_plugin(ds=1)
     interactive_pipeline(gui="auto", cache=True, safe_input_buffer_deepcopy=False)(
         deadleave_inference_pipeline)(model_dict)
 

--- a/src/rstor/analyzis/interactive/degradation.py
+++ b/src/rstor/analyzis/interactive/degradation.py
@@ -7,8 +7,8 @@ import cv2
 @interactive(
     sigma=(3/5, [0., 2.])
 )
-def downsample(chart: np.ndarray, sigma=3/5):
-    ds_factor = 5
+def downsample(chart: np.ndarray, sigma=3/5, global_params={}):
+    ds_factor = global_params.get("ds_factor", 5)
     if sigma > 0.:
         ds_chart = gaussian(chart, sigma=(sigma, sigma, 0), mode='nearest', cval=0, preserve_range=True, truncate=4.0)
     else:

--- a/src/rstor/architecture/base.py
+++ b/src/rstor/architecture/base.py
@@ -1,5 +1,11 @@
 import torch
-from rstor.properties import LEAKY_RELU, RELU
+from rstor.properties import LEAKY_RELU, RELU, SIMPLE_GATE
+
+
+class SimpleGate(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x1, x2 = x.chunk(2, dim=1)
+        return x1 * x2
 
 
 def get_non_linearity(activation: str):
@@ -9,6 +15,8 @@ def get_non_linearity(activation: str):
         non_linearity = torch.nn.ReLU()
     elif activation is None:
         non_linearity = torch.nn.Identity()
+    elif activation == SIMPLE_GATE:
+        non_linearity = SimpleGate()
     else:
         raise ValueError(f"Unknown activation {activation}")
     return non_linearity
@@ -26,7 +34,7 @@ class BaseModel(torch.nn.Module):
         Returns:
             int: receptive field
         """
-        input_tensor = torch.rand(1, 3, 128, 128, requires_grad=True)
+        input_tensor = torch.rand(1, 3, 256, 256, requires_grad=True)
         out = self.forward(input_tensor)
         grad = torch.zeros_like(out)
         grad[..., out.shape[-2]//2, out.shape[-1]//2] = torch.nan  # set NaN gradient at the middle of the output

--- a/src/rstor/architecture/base.py
+++ b/src/rstor/architecture/base.py
@@ -1,5 +1,6 @@
 import torch
 from rstor.properties import LEAKY_RELU, RELU, SIMPLE_GATE
+from typing import Optional
 
 
 class SimpleGate(torch.nn.Module):
@@ -28,13 +29,13 @@ class BaseModel(torch.nn.Module):
     def count_parameters(self):
         return sum(p.numel() for p in self.parameters() if p.requires_grad)
 
-    def receptive_field(self) -> int:
+    def receptive_field(self, channels: Optional[int] = 3, size: Optional[int] = 256) -> int:
         """Compute the receptive field of the model
 
         Returns:
             int: receptive field
         """
-        input_tensor = torch.rand(1, 3, 256, 256, requires_grad=True)
+        input_tensor = torch.ones(1, channels, size, size, requires_grad=True)
         out = self.forward(input_tensor)
         grad = torch.zeros_like(out)
         grad[..., out.shape[-2]//2, out.shape[-1]//2] = torch.nan  # set NaN gradient at the middle of the output

--- a/src/rstor/architecture/nafnet.py
+++ b/src/rstor/architecture/nafnet.py
@@ -1,0 +1,286 @@
+"""
+NAFNet: Non linear activation free neural network
+Architecture adapted from Simple Baselines for Image Restoration
+https://github.com/megvii-research/NAFNet/tree/main
+"""
+from torch import nn
+import torch.nn.functional as F
+import torch
+from rstor.architecture.base import BaseModel, get_non_linearity
+from typing import Optional, List
+from rstor.properties import RELU, SIMPLE_GATE
+
+
+class LayerNormFunction(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, x, weight, bias, eps):
+        ctx.eps = eps
+        N, C, H, W = x.size()
+        mu = x.mean(1, keepdim=True)
+        var = (x - mu).pow(2).mean(1, keepdim=True)
+        y = (x - mu) / (var + eps).sqrt()
+        ctx.save_for_backward(y, var, weight)
+        y = weight.view(1, C, 1, 1) * y + bias.view(1, C, 1, 1)
+        return y
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        eps = ctx.eps
+
+        N, C, H, W = grad_output.size()
+        y, var, weight = ctx.saved_variables
+        g = grad_output * weight.view(1, C, 1, 1)
+        mean_g = g.mean(dim=1, keepdim=True)
+
+        mean_gy = (g * y).mean(dim=1, keepdim=True)
+        gx = 1. / torch.sqrt(var + eps) * (g - y * mean_gy - mean_g)
+        return gx, (grad_output * y).sum(dim=3).sum(dim=2).sum(dim=0), grad_output.sum(dim=3).sum(dim=2).sum(
+            dim=0), None
+
+
+class LayerNorm2d(nn.Module):
+    def __init__(self, channels, eps=1e-6):
+        super(LayerNorm2d, self).__init__()
+        self.register_parameter('weight', nn.Parameter(torch.ones(channels)))
+        self.register_parameter('bias', nn.Parameter(torch.zeros(channels)))
+        self.eps = eps
+
+    def forward(self, x):
+        return LayerNormFunction.apply(x, self.weight, self.bias, self.eps)
+
+
+class NAFBlock(nn.Module):
+    def __init__(
+        self,
+        c, DW_Expand=2, FFN_Expand=2, drop_out_rate=0.,
+        activation: Optional[str] = SIMPLE_GATE,
+        layer_norm_flag: Optional[bool] = True,
+        channel_attention_flag: Optional[bool] = True,
+    ):
+        super().__init__()
+        self.layer_norm_flag = layer_norm_flag
+        self.channel_attention_flag = channel_attention_flag
+        dw_channel = c * DW_Expand
+        half_dw_channel = dw_channel // 2
+        self.conv1 = nn.Conv2d(in_channels=c, out_channels=dw_channel, kernel_size=1,
+                               padding=0, stride=1, groups=1, bias=True)
+        self.conv2 = nn.Conv2d(
+            in_channels=dw_channel,
+            out_channels=dw_channel if activation == SIMPLE_GATE else half_dw_channel,
+            kernel_size=3,
+            padding=1, stride=1,
+            groups=dw_channel if activation == SIMPLE_GATE else half_dw_channel,
+            bias=True
+        )
+        # To grand the same amount of parameters between Simple Gate and ReLU versions...
+        # Conv2 has to reduce the number of channels to half but... using grouped convolution
+        # w -> w/2 ... not really a depthwise convolution but rather by channels of 2!
+        self.conv3 = nn.Conv2d(in_channels=half_dw_channel, out_channels=c,
+                               kernel_size=1, padding=0, stride=1, groups=1, bias=True)
+
+        # Simplified Channel Attention
+        if self.channel_attention_flag:
+            self.sca = nn.Sequential(
+                nn.AdaptiveAvgPool2d(1),
+                nn.Conv2d(in_channels=half_dw_channel, out_channels=half_dw_channel, kernel_size=1,
+                          padding=0, stride=1,
+                          groups=1, bias=True),
+            )
+
+        # SimpleGate
+        self.sg = get_non_linearity(activation)
+        ffn_channel = FFN_Expand
+        half_ffn_channel = ffn_channel // 2 if activation == SIMPLE_GATE else ffn_channel
+        self.conv4 = nn.Conv2d(
+            in_channels=c,
+            out_channels=ffn_channel if activation == SIMPLE_GATE else half_ffn_channel,
+            kernel_size=1,
+            padding=0, stride=1, groups=1, bias=True)
+        self.conv5 = nn.Conv2d(in_channels=half_ffn_channel, out_channels=c,
+                               kernel_size=1, padding=0, stride=1, groups=1, bias=True)
+        if self.layer_norm_flag:
+            self.norm1 = LayerNorm2d(c)
+            self.norm2 = LayerNorm2d(c)
+
+        self.dropout1 = nn.Dropout(drop_out_rate) if drop_out_rate > 0. else nn.Identity()
+        self.dropout2 = nn.Dropout(drop_out_rate) if drop_out_rate > 0. else nn.Identity()
+
+        self.beta = nn.Parameter(torch.zeros((1, c, 1, 1)), requires_grad=True)
+        self.gamma = nn.Parameter(torch.zeros((1, c, 1, 1)), requires_grad=True)
+
+    def forward(self, inp):
+        x = inp
+        if self.layer_norm_flag:
+            x = self.norm1(x)
+
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.sg(x)
+        if self.channel_attention_flag:
+            x = x * self.sca(x)
+        x = self.conv3(x)
+
+        x = self.dropout1(x)
+
+        y = inp + x * self.beta
+
+        x = self.conv4(self.norm2(y) if self.layer_norm_flag else y)
+        x = self.sg(x)
+        x = self.conv5(x)
+
+        x = self.dropout2(x)
+
+        return y + x * self.gamma
+
+
+class NAFNet(BaseModel):
+    def __init__(
+            self,
+            img_channel: Optional[int] = 3,
+            width: Optional[int] = 16,
+            middle_blk_num: Optional[int] = 1,
+            enc_blk_nums: List[int] = [],
+            dec_blk_nums: List[int] = [],
+            activation: Optional[bool] = SIMPLE_GATE,
+            layer_norm_flag: Optional[bool] = True,
+            channel_attention_flag: Optional[bool] = True,
+    ) -> None:
+        super().__init__()
+
+        self.intro = nn.Conv2d(
+            in_channels=img_channel,
+            out_channels=width,
+            kernel_size=3,
+            padding=1, stride=1,
+            groups=1,
+            bias=True
+        )
+        config_block = {
+            "activation": activation,
+            "layer_norm_flag": layer_norm_flag,
+            "channel_attention_flag": channel_attention_flag
+        }
+        self.ending = nn.Conv2d(
+            in_channels=width, out_channels=img_channel, kernel_size=3,
+            padding=1, stride=1, groups=1,
+            bias=True)
+
+        self.encoders = nn.ModuleList()
+        self.decoders = nn.ModuleList()
+        self.middle_blks = nn.ModuleList()
+        self.ups = nn.ModuleList()
+        self.downs = nn.ModuleList()
+
+        chan = width
+        for num in enc_blk_nums:
+            self.encoders.append(
+                nn.Sequential(
+                    *[NAFBlock(chan, **config_block) for _ in range(num)]
+                )
+            )
+            self.downs.append(
+                nn.Conv2d(chan, 2*chan, 2, 2)
+            )
+            chan = chan * 2
+
+        self.middle_blks = \
+            nn.Sequential(
+                *[NAFBlock(chan, **config_block) for _ in range(middle_blk_num)]
+            )
+
+        for num in dec_blk_nums:
+            self.ups.append(
+                nn.Sequential(
+                    nn.Conv2d(chan, chan * 2, 1, bias=False),
+                    nn.PixelShuffle(2)
+                )
+            )
+            chan = chan // 2
+            self.decoders.append(
+                nn.Sequential(
+                    *[NAFBlock(chan, **config_block) for _ in range(num)]
+                )
+            )
+
+        self.padder_size = 2 ** len(self.encoders)
+
+    def forward(self, inp: torch.Tensor) -> torch.Tensor:
+        B, C, H, W = inp.shape
+        inp = self.sanitize_image_size(inp)
+
+        x = self.intro(inp)
+
+        encs = []
+
+        for encoder, down in zip(self.encoders, self.downs):
+            x = encoder(x)
+            encs.append(x)
+            x = down(x)
+
+        x = self.middle_blks(x)
+
+        for decoder, up, enc_skip in zip(self.decoders, self.ups, encs[::-1]):
+            x = up(x)
+            x = x + enc_skip
+            x = decoder(x)
+
+        x = self.ending(x)
+        x = x + inp
+
+        return x[:, :, :H, :W]
+
+    def sanitize_image_size(self, x: torch.Tensor) -> torch.Tensor:
+        _, _, h, w = x.size()
+        mod_pad_h = (self.padder_size - h % self.padder_size) % self.padder_size
+        mod_pad_w = (self.padder_size - w % self.padder_size) % self.padder_size
+        x = F.pad(x, (0, mod_pad_w, 0, mod_pad_h))
+        return x
+
+
+class UNet(NAFNet):
+    def __init__(
+            self,
+            activation: Optional[bool] = RELU,
+            layer_norm_flag: Optional[bool] = False,
+            channel_attention_flag: Optional[bool] = False,
+            **kwargs):
+        super().__init__(
+            activation=activation,
+            layer_norm_flag=layer_norm_flag,
+            channel_attention_flag=channel_attention_flag, **kwargs)
+
+
+if __name__ == '__main__':
+    enc_blks = [1, 1, 1, 4]
+    middle_blk_num = 1
+    dec_blks = [1, 1, 1, 28]
+    width = 16
+    for model_name in ["NAFNet", "UNet"]:
+        if model_name == "NAFNet":
+            model = NAFNet(
+                img_channel=3,
+                width=width,
+                middle_blk_num=middle_blk_num,
+                enc_blk_nums=enc_blks,
+                dec_blk_nums=dec_blks,
+                activation=SIMPLE_GATE,
+                layer_norm_flag=False,
+                channel_attention_flag=False
+            )
+        if model_name == "UNet":
+            model = UNet(
+                img_channel=3,
+                width=width,
+                middle_blk_num=middle_blk_num,
+                enc_blk_nums=enc_blks,
+                dec_blk_nums=dec_blks
+            )
+        x = torch.randn(1, 3, 256, 256)
+        y = model(x)
+
+        # print(y.shape)
+        # print(y)
+        # print(model)
+        print(f"{model.count_parameters()/1E3:.2f}k parameters")
+        print(model.receptive_field())

--- a/src/rstor/architecture/selector.py
+++ b/src/rstor/architecture/selector.py
@@ -1,11 +1,17 @@
 from rstor.properties import MODEL, NAME, N_PARAMS, ARCHITECTURE
 from rstor.architecture.stacked_convolutions import StackedConvolutions
+from rstor.architecture.nafnet import NAFNet, UNet
 import torch
 
 
 def load_architecture(config: dict) -> torch.nn.Module:
+    conf_model = config[MODEL][ARCHITECTURE]
     if config[MODEL][NAME] == StackedConvolutions.__name__:
-        model = StackedConvolutions(**config[MODEL][ARCHITECTURE])
+        model = StackedConvolutions(**conf_model)
+    elif config[MODEL][NAME] == NAFNet.__name__:
+        model = NAFNet(**conf_model)
+    elif config[MODEL][NAME] == UNet.__name__:
+        model = UNet(**conf_model)
     else:
         raise ValueError(f"Unknown model {config[MODEL][NAME]}")
     config[MODEL][N_PARAMS] = model.count_parameters()

--- a/src/rstor/learning/experiments_definition.py
+++ b/src/rstor/learning/experiments_definition.py
@@ -93,11 +93,11 @@ def get_experiment_config(exp: int) -> dict:
     elif exp == 1004:
         config = presets_experiments(exp, n=60)
         config[DATALOADER][CONFIG_DEAD_LEAVES] = dict(blur_kernel_half_size=[0, 0], ds_factor=1, noise_stddev=[0., 50.])
-        config[PRETTY_NAME] = "Vanilla denoise only - ds=5 - noisy 0-50"
+        config[PRETTY_NAME] = "Vanilla denoise only - ds=1 - noisy 0-50"
     elif exp == 1005:
         config = presets_experiments(exp, bias=False, n=60)
         config[DATALOADER][CONFIG_DEAD_LEAVES] = dict(blur_kernel_half_size=[0, 0], ds_factor=1, noise_stddev=[0., 50.])
-        config[PRETTY_NAME] = "Vanilla denoise only - ds=5 - noisy 0-50 - bias free"
+        config[PRETTY_NAME] = "Vanilla denoise only - ds=1 - noisy 0-50 - bias free"
     elif exp == 1006:
         config = presets_experiments(exp, n=60)
         config[PRETTY_NAME] = "Vanilla small blur - noisy 0-50"

--- a/src/rstor/learning/experiments_definition.py
+++ b/src/rstor/learning/experiments_definition.py
@@ -114,6 +114,14 @@ def get_experiment_config(exp: int) -> dict:
             ds_factor=1,
             noise_stddev=[0., 50.]
         )
+    elif exp == 2001:
+        config = presets_experiments(exp, n=60,  b=16, model_preset="UNEt")
+        config[PRETTY_NAME] = "UNEt denoise 0-50"
+        config[DATALOADER][CONFIG_DEAD_LEAVES] = dict(
+            blur_kernel_half_size=[0, 0],
+            ds_factor=1,
+            noise_stddev=[0., 50.]
+        )
     else:
         raise ValueError(f"Experiment {exp} not found")
     return config

--- a/src/rstor/learning/experiments_definition.py
+++ b/src/rstor/learning/experiments_definition.py
@@ -115,7 +115,7 @@ def get_experiment_config(exp: int) -> dict:
             noise_stddev=[0., 50.]
         )
     elif exp == 2001:
-        config = presets_experiments(exp, n=60,  b=16, model_preset="UNEt")
+        config = presets_experiments(exp, n=60,  b=16, model_preset="UNet")
         config[PRETTY_NAME] = "UNEt denoise 0-50"
         config[DATALOADER][CONFIG_DEAD_LEAVES] = dict(
             blur_kernel_half_size=[0, 0],

--- a/src/rstor/properties.py
+++ b/src/rstor/properties.py
@@ -1,6 +1,7 @@
 import torch
 RELU = "ReLU"
 LEAKY_RELU = "LeakyReLU"
+SIMPLE_GATE = "simple_gate"
 LOSS = "loss"
 LOSS_MSE = "MSE"
 METRIC_PSNR = "PSNR"

--- a/src/rstor/synthetic_data/interactive/interactive_dead_leaves.py
+++ b/src/rstor/synthetic_data/interactive/interactive_dead_leaves.py
@@ -14,10 +14,9 @@ def dead_leave_plugin(ds=1):
         radius_mean=(-1., [-1., 200]),
         radius_stddev=(-1., [-1., 100.]),
         seed=(0, [-1, 42]),
-        ds=(ds, [ds, ds]),
+        ds=(ds, [1, 5]),
         numba_flag=(False,),  # Default CPU to avoid issues by default
         # ds=(ds, [1, 5])
-
     )(generate_deadleave)
 
 
@@ -29,8 +28,10 @@ def generate_deadleave(
     radius_stddev: Optional[int] = -1,
     seed=0,
     ds=3,
-    numba_flag=True
+    numba_flag=True,
+    global_params={}
 ) -> np.ndarray:
+    global_params["ds_factor"] = ds
     bg_color = (background_intensity, background_intensity, background_intensity)
     if not numba_flag:
         chart = dead_leaves_chart((512*ds, 512*ds), number_of_circles, bg_color, colored, radius_mean, radius_stddev,

--- a/test/test_nafnet.py
+++ b/test/test_nafnet.py
@@ -1,0 +1,19 @@
+import torch
+from rstor.architecture.nafnet import NAFNet
+
+
+def test_nafnet():
+    enc_blks = [1, 1]
+    middle_blk_num = 1
+    dec_blks = [1, 2]
+
+    model = NAFNet(
+        img_channel=3,
+        width=2,
+        middle_blk_num=middle_blk_num,
+        enc_blk_nums=enc_blks,
+        dec_blk_nums=dec_blks,
+    )
+    x = torch.rand(2, 3, 128, 128)
+    y = model(x)
+    assert y.shape == (2, 3, 128, 128)

--- a/test/test_unet.py
+++ b/test/test_unet.py
@@ -1,0 +1,27 @@
+import torch
+from rstor.architecture.nafnet import UNet
+from rstor.properties import LEAKY_RELU
+
+
+def test_unet():
+    enc_blks = [1, 2]
+    middle_blk_num = 2
+    dec_blks = [2, 1]
+
+    model = UNet(
+        img_channel=3,
+        width=2,
+        activation=LEAKY_RELU,
+        # We need leaky relu ...
+        # otherwise it seems like ReLU may block propagation of NaN (with zeros!)
+        # NaN and ReLu do not work correctly for receptive field estimation technique
+        middle_blk_num=middle_blk_num,
+        enc_blk_nums=enc_blks,
+        dec_blk_nums=dec_blks,
+    )
+    rx, ry = model.receptive_field(channels=3)
+    assert rx == ry
+    assert rx == 44, "Receptive field should be {rx} x {ry}"
+    x = torch.rand(2, 3, 128, 128)
+    y = model(x)
+    assert y.shape == (2, 3, 128, 128)


### PR DESCRIPTION
![image](https://github.com/balthazarneveu/blind-deblurring-from-synthetic-data/assets/41070742/6b825e28-f4ee-4e90-b632-23e3b517612a)
- Ability to train NAFNet

 #### NAFNet detail
Important to know:  NAFNet configuration files provide the correct configuration (during their training) https://github.com/megvii-research/NAFNet/blob/main/options/train/GoPro/NAFNet-width64.yml

#### UNET
- Created a UNET which is almost the same as NAFNEt without channel attentions, layer normalization and simple gate is replaced by a ReLU
- Please beware that the 2 networks have the same amount of parameters but the weird fact is that since the gate activation inherently reduces channels by two, I had to adapt the amount of channels outputs used in the convolution precedig the gate -> not really deptwise.